### PR TITLE
use add/update/delete: id-broker, turbine 4.1-SNAPSHOT and security 1.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 					<include>**/*.properties</include>
 				</includes>
 			</resource>
+      
 
 			<!-- (target) resource and filtering is not used at all ? at least removed 
 				setting absolute path e.g. with ${project.build.directory}, which does thrown 
@@ -163,39 +164,6 @@
 					</dependency>
 				</dependencies>
 				<!-- this is mysql specific -->
-				<!-- executions>
-					<execution>
-						<id>create-db</id>
-						<phase>pre-integration-test</phase>
-						<goals>
-							<goal>execute</goal>
-						</goals>
-						<configuration>
-							<orderFile>ascending</orderFile>
-							<fileset>
-								<basedir>${project.build.directory}/generated-sql/torque/mysql</basedir-->
-								<!-- basedir>${basedir}/target/generated-sql</basedir -->
-								<!--includes>
-									<include>*.sql</include>
-								</includes>
-							</fileset>
-						</configuration>
-					</execution>
-					<execution>
-						<id>create-data</id>
-						<phase>pre-integration-test</phase>
-						<goals>
-							<goal>execute</goal>
-						</goals>
-						<configuration>
-							<orderFile>ascending</orderFile>
-							<srcFiles>
-								<srcFile>${project.basedir}/docs/sample-mysql-data/_application-data.sql</srcFile>
-								<srcFile>${project.basedir}/docs/sample-mysql-data/_turbine-security-data.sql</srcFile>
-							</srcFiles>
-						</configuration>
-					</execution>
-				</executions-->
 			</plugin>
 
 			<!-- jetty:run checks deployed war http://localhost:8081/app/ Using jetty 
@@ -207,6 +175,7 @@
 				<configuration>
 					<scanIntervalSeconds>10</scanIntervalSeconds>
 					<dumpOnStart>true</dumpOnStart>
+          <reload>manual</reload>
 					<connectors>
 						<connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
 							<port>8081</port>
@@ -247,7 +216,7 @@
 		<dependency>
 			<groupId>org.apache.turbine</groupId>
 			<artifactId>turbine</artifactId>
-			<version>4.0</version>
+			<version>${turbine.core}</version>
 		</dependency>
 		<!-- yaafi is optional. NOTICE: 1.0.7 has group org.apache.turbine not 
 			org.apache.fulcrum -->
@@ -288,6 +257,13 @@
 			<artifactId>fulcrum-security-api</artifactId>
 			<version>${fulcrum.security}</version>
 		</dependency>
+    <dependency>
+      <groupId>org.apache.fulcrum</groupId>
+      <artifactId>fulcrum-security-api</artifactId>
+      <version>${fulcrum.security}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
 		<dependency>
 			<groupId>org.apache.fulcrum</groupId>
 			<artifactId>fulcrum-json-jackson2</artifactId>
@@ -322,7 +298,8 @@
 		<maven.compile.target>1.7</maven.compile.target>
 		<project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
 		<fulcrum.json>1.1.1</fulcrum.json>
-		<fulcrum.security>1.1.1</fulcrum.security>
+		<fulcrum.security>1.1.2-SNAPSHOT</fulcrum.security>
+    <turbine.core>4.1-SNAPSHOT</turbine.core>
 	</properties>
 
 </project>

--- a/src/main/torque-schema/torque-security-schema.xml
+++ b/src/main/torque-schema/torque-security-schema.xml
@@ -81,12 +81,12 @@
     </foreign-key>
   </table>
 
-  <table name="TURBINE_USER" idMethod="native" 
+  <table name="TURBINE_USER" idMethod="idbroker" 
   	baseClass="org.apache.fulcrum.security.torque.turbine.DefaultAbstractTurbineUser"
   	interface="org.apache.fulcrum.security.model.turbine.entity.TurbineUser">
   	
-    <column name="USER_ID"	primaryKey="true"	required="true" type="INTEGER"	javaType="object"	javaName="EntityId"/>
-    <column name="LOGIN_NAME"		required="true"	size="64"	type="VARCHAR"	javaName="EntityName"/>
+    <column name="USER_ID"	primaryKey="true"	required="true" type="INTEGER"	javaType="object"	javaName="EntityId" autoIncrement="true"/>
+    <column name="LOGIN_NAME"		required="true"	size="64"	type="VARCHAR"	javaName="EntityName" />
     <column name="PASSWORD_VALUE"	required="true"	size="16"	type="VARCHAR"	javaName="Password"/>
     <column name="FIRST_NAME"		required="true"	size="64"	type="VARCHAR"/>
     <column name="LAST_NAME"		required="true"	size="64"	type="VARCHAR"/>


### PR DESCRIPTION
Just proof of concept example to show, that the managers might work after applying the discussed changes:
prerequisites (in pom)
- build local Turbine core trunk (4.1-SNAPSHOT)
- build local Fulcrum Security trunk (1.1.2-SNAPSHOT)
I changed in schema idMethod to idBroker e.g. and did
- INSERT INTO id_table (id_table_id, table_name, next_id, quantity) VALUES (1,'turbine_user',1,100);
alternatively you may add attribute  autoIncrement="true" to coumn user_id in table turbine_user in schema and add to mysql to field 
ALTER TABLE turbine_user MODIFY COLUMN user_id INT auto_increment;

Otherwise you get java.sql.SQLException: Field 'USER_ID' doesn't have a default value.

I tested the user add/delete. Ignore other changes (I changed reload to manual, and started adding test requirements). It might work even with current Fulcrum Security 1.1.1, as no major changes are done there. 

